### PR TITLE
rp2/boards/ADAFRUIT_FRUIT_JAM: Enable WiFi and Bluetooth via NINA-W10

### DIFF
--- a/drivers/ninaw10/nina_wifi_drv.c
+++ b/drivers/ninaw10/nina_wifi_drv.c
@@ -266,18 +266,31 @@ static int nina_read_response(uint32_t cmd, uint32_t nvals, uint32_t width, nina
         goto error_out;
     }
 
-    // Sanity check the number of returned values.
-    // NOTE: This is to handle the special case for the scan command.
-    if (nvals > header[2]) {
-        nvals = header[2];
-    }
+    // The firmware may return more values than the caller asked for (e.g. the
+    // scan command returns one value per network found, which can exceed
+    // NINA_MAX_NETWORK_LIST). Every value must still be read off the wire so
+    // the CMD_END terminator below lines up, so only clamp how many are kept.
+    uint32_t nvals_avail = header[2];
+    uint32_t nvals_read = MIN(nvals, nvals_avail);
 
     // Read return value(s).
-    for (uint32_t i = 0; i < nvals; i++) {
+    for (uint32_t i = 0; i < nvals_avail; i++) {
         // Read return value size.
         uint16_t bytes = nina_bsp_spi_read_byte();
         if (width == ARG_16BITS) {
             bytes = (bytes << 8) | nina_bsp_spi_read_byte();
+        }
+
+        if (i >= nvals_read) {
+            // Discard values beyond what the caller asked for.
+            uint8_t discard[32];
+            for (uint16_t n = 0; n < bytes; n += sizeof(discard)) {
+                if (nina_bsp_spi_transfer(NULL, discard, MIN(bytes - n, sizeof(discard))) != 0) {
+                    goto error_out;
+                }
+            }
+            length += bytes + width;
+            continue;
         }
 
         // Check the val fits the buffer.

--- a/ports/rp2/boards/ADAFRUIT_FRUIT_JAM/manifest.py
+++ b/ports/rp2/boards/ADAFRUIT_FRUIT_JAM/manifest.py
@@ -1,3 +1,9 @@
 include("$(PORT_DIR)/boards/manifest.py")
 
 require("sdcard")
+
+# Networking
+require("bundle-networking")
+
+# ESP32-C6 AirLift firmware updater
+require("espflash")

--- a/ports/rp2/boards/ADAFRUIT_FRUIT_JAM/mpconfigboard.cmake
+++ b/ports/rp2/boards/ADAFRUIT_FRUIT_JAM/mpconfigboard.cmake
@@ -14,3 +14,8 @@ endif()
 # 8MB PSRAM on GPIO47.
 set(MICROPY_HW_ENABLE_PSRAM 1)
 set(MICROPY_HW_PSRAM_CS_PIN 47)
+
+# WiFi/Bluetooth via the ESP32-C6 AirLift (nina-fw) co-processor.
+set(MICROPY_PY_BLUETOOTH 1)
+set(MICROPY_BLUETOOTH_NIMBLE 1)
+set(MICROPY_PY_NETWORK_NINAW10 1)

--- a/ports/rp2/boards/ADAFRUIT_FRUIT_JAM/mpconfigboard.h
+++ b/ports/rp2/boards/ADAFRUIT_FRUIT_JAM/mpconfigboard.h
@@ -4,6 +4,8 @@
 // PERIPH_RESET (GPIO22) is shared between the TLV320DAC3100 audio codec and the
 // ESP32-C6 co-processor and is held low (in reset) by default. Release it at
 // startup so the codec responds on I2C0, matching the reference firmware.
+// Note this pin also doubles as the ESP32-C6 reset line (MICROPY_HW_NINA_RESET
+// below), so enabling the WiFi/BLE radio resets the audio codec as well.
 #define MICROPY_BOARD_STARTUP ADAFRUIT_FRUIT_JAM_board_startup
 void ADAFRUIT_FRUIT_JAM_board_startup(void);
 
@@ -19,13 +21,36 @@ void ADAFRUIT_FRUIT_JAM_board_startup(void);
 #define MICROPY_HW_SPI0_MOSI (35)
 #define MICROPY_HW_SPI0_MISO (36)
 
-// ESP32-C6 co-processor bus / STEMMA "SPI" -- general purpose only, no driver
+// ESP32-C6 co-processor bus / STEMMA "SPI" (also used by the NINA-W10 WiFi driver below)
 #define MICROPY_HW_SPI1_SCK  (30)
 #define MICROPY_HW_SPI1_MOSI (31)
 #define MICROPY_HW_SPI1_MISO (28)
 
-// Shared with ESP32-C6 UART (D6/D7 header pins)
+// Shared with ESP32-C6 UART (D6/D7 header pins), used by the NINA-W10 Bluetooth HCI below
 #define MICROPY_HW_UART1_TX  (8)
 #define MICROPY_HW_UART1_RX  (9)
 #define MICROPY_HW_UART1_CTS (-1)
 #define MICROPY_HW_UART1_RTS (-1)
+
+// Enable networking.
+#define MICROPY_PY_NETWORK                  (1)
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-fruit-jam"
+
+// The NINA-W10 driver's errno values come from the AirLift co-processor's own
+// newlib-based errno numbering (e.g. EINPROGRESS=119), not MicroPython's
+// internal compact table, so route OSError through the real errno.h values.
+#define MICROPY_USE_INTERNAL_ERRNO (0)
+
+// Bluetooth config: ESP32-C6 AirLift (nina-fw) HCI over UART1.
+#define MICROPY_HW_BLE_UART_ID       (1)
+#define MICROPY_HW_BLE_UART_BAUDRATE (115200)
+
+// WiFi config: ESP32-C6 AirLift (nina-fw) over SPI1.
+#define MICROPY_HW_WIFI_SPI_ID       (1)
+#define MICROPY_HW_WIFI_SPI_BAUDRATE (8 * 1000 * 1000)
+
+// ESP32-C6 AirLift (nina-fw) control pins.
+#define MICROPY_HW_NINA_RESET (22)  // WIFI_RESET / PERIPH_RESET
+#define MICROPY_HW_NINA_GPIO0 (23)  // WIFI_IRQ
+#define MICROPY_HW_NINA_GPIO1 (46)  // WIFI_CS
+#define MICROPY_HW_NINA_ACK   (3)   // WIFI_BUSY


### PR DESCRIPTION
### Summary
The Fruit Jam's onboard ESP32-C6 co-processor runs Adafruit's AirLift firmware, which is a nina-fw fork speaking the same wire protocol as the NINA-W10 modules already supported by this port (e.g. Arduino Nano RP2040 Connect). This wires the existing driver up to the AirLift's SPI1/UART1 link and control pins on top of your board bring-up.

Also includes a fix to the shared NINA-W10 driver: scan() was silently returning zero results whenever more than 10 APs were in range (common in dense WiFi environments), because the response parser desynced the SPI stream when the firmware reported more values than the caller requested. Not Fruit Jam specific, but needed to get scan working here and benefits the Nano RP2040 Connect too.

### Testing
Tested on actual Fruit Jam hardware: WiFi scan (returns real SSIDs/BSSIDs/RSSI/channel), STA connect + DHCP, and TCP sockets (HTTP request/response) all confirmed working.